### PR TITLE
updates for Beat Saber 1.37.5

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -47,15 +47,13 @@ namespace bsrpc
         [OnEnable]
         public void OnEnable()
         {
-
-            BSMLSettings.instance.RemoveSettingsMenu(Settings.instance);
-            BSMLSettings.instance.AddSettingsMenu("bsrpc", "bsrpc.UI.SettingsViewController.bsml", Settings.instance);
+            SettingsMenuManager.Initialize();
         }
 
         [OnDisable]
         public void OnDisable()
         {
-            BSMLSettings.instance.RemoveSettingsMenu(Settings.instance);
+            SettingsMenuManager.Disable();
         }
 
         private void HandleConfigUpdate()

--- a/UI/SettingsMenuManager.cs
+++ b/UI/SettingsMenuManager.cs
@@ -1,0 +1,33 @@
+﻿using BeatSaberMarkupLanguage.Settings;
+using BeatSaberMarkupLanguage.Util;
+
+namespace bsrpc.UI
+{
+    internal class SettingsMenuManager
+    {
+        private static bool DidInit { get; set; } = false;
+
+        private const string MenuName = "bsrpc";
+        private const string ResourcePath = "bsrpc.UI.SettingsViewController.bsml";
+
+        public static void Initialize()
+        {
+            if (!DidInit)
+            {
+                MainMenuAwaiter.MainMenuInitializing += InitOnMainMenuLoaded;
+                DidInit = true;
+            }
+        }
+
+        public static void Disable()
+        {
+            MainMenuAwaiter.MainMenuInitializing -= InitOnMainMenuLoaded;
+            BSMLSettings.Instance.RemoveSettingsMenu(Settings.instance);
+        }
+
+        private static void InitOnMainMenuLoaded()
+        {
+            BSMLSettings.Instance.AddSettingsMenu(MenuName, ResourcePath, Settings.instance);
+        }
+    }
+}

--- a/UI/SettingsMenuManager.cs
+++ b/UI/SettingsMenuManager.cs
@@ -22,6 +22,7 @@ namespace bsrpc.UI
         public static void Disable()
         {
             MainMenuAwaiter.MainMenuInitializing -= InitOnMainMenuLoaded;
+            DidInit = false;
             BSMLSettings.Instance.RemoveSettingsMenu(Settings.instance);
         }
 

--- a/bsrpc.csproj
+++ b/bsrpc.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RichPresenceResources.cs" />
     <Compile Include="UI\Settings.cs" />
+    <Compile Include="UI\SettingsMenuManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />


### PR DESCRIPTION
- BSML menus need to be created after the menu scene loads, the `SettingsMenuManager` uses a BSML event to do this