### PR TITLE
Support MultiplayerCore lobby mod name in join secrets via URI path segment

### DIFF
--- a/DataMappers.cs
+++ b/DataMappers.cs
@@ -1,4 +1,4 @@
-﻿using DataPuller.Data;
+﻿ using DataPuller.Data;
 using Discord;
 using System;
 using System.Collections.Generic;
@@ -352,7 +352,7 @@ namespace bsrpc
                             var modName = MapData.Instance.MultiplayerCoreLobbyMod;
                             activity.Secrets.Join = string.IsNullOrEmpty(modName)
                                 ? $"bsrpc://{source}/{joinCode}"
-                                : $"bsrpc://{source}/{joinCode}?mod={modName}";
+                                : $"bsrpc://{source}/{modName}/{joinCode}";
                         }
                     }
                 }

--- a/DataMappers.cs
+++ b/DataMappers.cs
@@ -349,7 +349,10 @@ namespace bsrpc
                         if (!string.IsNullOrEmpty(joinCode) && !string.IsNullOrEmpty(source))
                         {
                             activity.Party.Id = joinCode;
-                            activity.Secrets.Join = $"bsrpc://{source}/{joinCode}";
+                            var modName = MapData.Instance.MultiplayerCoreLobbyMod;
+                            activity.Secrets.Join = string.IsNullOrEmpty(modName)
+                                ? $"bsrpc://{source}/{joinCode}"
+                                : $"bsrpc://{source}/{joinCode}?mod={modName}";
                         }
                     }
                 }

--- a/DataMappers.cs
+++ b/DataMappers.cs
@@ -2,6 +2,7 @@
 using Discord;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -129,6 +130,17 @@ namespace bsrpc
                 return PluginConfig.Instance.LobbyTypeEmoji.Practice;
             }
             return PluginConfig.Instance.LobbyTypeEmoji.Singleplayer;
+        }
+
+        internal static string HashPartyId(string input)
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(input));
+                var sb = new StringBuilder(hash.Length * 2);
+                foreach (var b in hash) sb.AppendFormat("{0:x2}", b);
+                return sb.ToString();
+            }
         }
 
         internal static long DateTimeToUnixTimestampMs(DateTime ticks)
@@ -348,7 +360,7 @@ namespace bsrpc
                         var source = MapData.Instance.MultiplayerLobbySource;
                         if (!string.IsNullOrEmpty(joinCode) && !string.IsNullOrEmpty(source))
                         {
-                            activity.Party.Id = joinCode;
+                            activity.Party.Id = HashPartyId(joinCode);
                             var modName = MapData.Instance.MultiplayerCoreLobbyMod;
                             activity.Secrets.Join = string.IsNullOrEmpty(modName)
                                 ? $"bsrpc://{source}/{joinCode}"

--- a/Harmony/MultiplayerJoinService.cs
+++ b/Harmony/MultiplayerJoinService.cs
@@ -7,9 +7,9 @@ namespace bsrpc.Harmony
     {
         internal static string _pendingCode;
         internal static string _pendingSource;
-        internal static string? _pendingMod;
+        internal static string _pendingMod;
 
-        internal static void RequestJoin(string source, string code, string? modName = null)
+        internal static void RequestJoin(string source, string code, string modName = null)
         {
             _pendingSource = source;
             _pendingCode = code;

--- a/Harmony/MultiplayerJoinService.cs
+++ b/Harmony/MultiplayerJoinService.cs
@@ -7,21 +7,25 @@ namespace bsrpc.Harmony
     {
         internal static string _pendingCode;
         internal static string _pendingSource;
+        internal static string? _pendingMod;
 
-        internal static void RequestJoin(string source, string code)
+        internal static void RequestJoin(string source, string code, string? modName = null)
         {
             _pendingSource = source;
             _pendingCode = code;
+            _pendingMod = modName;
             var hint = source == MultiplayerLobbySourceType.BeatSaberPlus_Multiplayer
                 ? "navigate to Multiplayer+ to auto-join"
                 : "navigate to Multiplayer to auto-join";
-            Plugin.Log.Info($"Join queued ({source}/{code}) — {hint}");
+            var modInfo = modName != null ? $", mod={modName}" : "";
+            Plugin.Log.Info($"Join queued ({source}/{code}{modInfo}) — {hint}");
         }
 
         internal static void Clear()
         {
             _pendingSource = null;
             _pendingCode = null;
+            _pendingMod = null;
         }
     }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -114,7 +114,7 @@ namespace bsrpc
         {
             Log.Debug($"Activity join event received, secret: {secret}");
             if (!PluginConfig.Instance.MultiplayerLobbyJoining) return;
-            // Expected format: bsrpc://Source/JOINCODE
+            // Expected format: bsrpc://Source/JOINCODE or bsrpc://Source/JOINCODE?mod=Name
             if (secret.StartsWith("bsrpc://"))
             {
                 var path = secret.Substring("bsrpc://".Length);
@@ -122,12 +122,30 @@ namespace bsrpc
                 if (slash > 0)
                 {
                     var source = path.Substring(0, slash);
-                    var code = path.Substring(slash + 1);
-                    MultiplayerJoinService.RequestJoin(source, code);
+                    var codeAndQuery = path.Substring(slash + 1);
+                    string? modName = null;
+                    var queryIdx = codeAndQuery.IndexOf('?');
+                    if (queryIdx >= 0)
+                    {
+                        modName = ParseModParam(codeAndQuery.Substring(queryIdx + 1));
+                        codeAndQuery = codeAndQuery.Substring(0, queryIdx);
+                    }
+                    MultiplayerJoinService.RequestJoin(source, codeAndQuery, modName);
                     return;
                 }
             }
             Log.Warn($"Activity join: unrecognised secret format: {secret}");
+        }
+
+        private static string? ParseModParam(string query)
+        {
+            foreach (var param in query.Split('&'))
+            {
+                var eq = param.IndexOf('=');
+                if (eq > 0 && param.Substring(0, eq) == "mod")
+                    return param.Substring(eq + 1);
+            }
+            return null;
         }
 
         private void OnActivityJoinRequest(ref User user)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -9,6 +9,7 @@ using IPA.Config.Stores;
 using System;
 using System.Reflection;
 using System.Timers;
+using System.Web;
 using UnityEngine;
 using IPALogger = IPA.Logging.Logger;
 
@@ -114,38 +115,15 @@ namespace bsrpc
         {
             Log.Debug($"Activity join event received, secret: {secret}");
             if (!PluginConfig.Instance.MultiplayerLobbyJoining) return;
-            // Expected format: bsrpc://Source/JOINCODE or bsrpc://Source/JOINCODE?mod=Name
-            if (secret.StartsWith("bsrpc://"))
+            if (Uri.TryCreate(secret, UriKind.Absolute, out var uri) && uri.Scheme == "bsrpc")
             {
-                var path = secret.Substring("bsrpc://".Length);
-                var slash = path.IndexOf('/');
-                if (slash > 0)
-                {
-                    var source = path.Substring(0, slash);
-                    var codeAndQuery = path.Substring(slash + 1);
-                    string? modName = null;
-                    var queryIdx = codeAndQuery.IndexOf('?');
-                    if (queryIdx >= 0)
-                    {
-                        modName = ParseModParam(codeAndQuery.Substring(queryIdx + 1));
-                        codeAndQuery = codeAndQuery.Substring(0, queryIdx);
-                    }
-                    MultiplayerJoinService.RequestJoin(source, codeAndQuery, modName);
-                    return;
-                }
+                var source = uri.Host;
+                var code = uri.AbsolutePath.TrimStart('/');
+                var mod = HttpUtility.ParseQueryString(uri.Query)["mod"];
+                MultiplayerJoinService.RequestJoin(source, code, mod);
+                return;
             }
             Log.Warn($"Activity join: unrecognised secret format: {secret}");
-        }
-
-        private static string? ParseModParam(string query)
-        {
-            foreach (var param in query.Split('&'))
-            {
-                var eq = param.IndexOf('=');
-                if (eq > 0 && param.Substring(0, eq) == "mod")
-                    return param.Substring(eq + 1);
-            }
-            return null;
         }
 
         private void OnActivityJoinRequest(ref User user)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using bsrpc.Harmony;
+﻿ using bsrpc.Harmony;
 using bsrpc.UI;
 using DataPuller.Data;
 using Discord;
@@ -9,7 +9,6 @@ using IPA.Config.Stores;
 using System;
 using System.Reflection;
 using System.Timers;
-using System.Web;
 using UnityEngine;
 using IPALogger = IPA.Logging.Logger;
 
@@ -118,8 +117,9 @@ namespace bsrpc
             if (Uri.TryCreate(secret, UriKind.Absolute, out var uri) && uri.Scheme == "bsrpc")
             {
                 var source = uri.Host;
-                var code = uri.AbsolutePath.TrimStart('/');
-                var mod = HttpUtility.ParseQueryString(uri.Query)["mod"];
+                var segments = uri.AbsolutePath.TrimStart('/').Split(new[] { '/' }, 2);
+                var code = segments.Length > 1 ? segments[1] : segments[0];
+                var mod = segments.Length > 1 ? segments[0] : null;
                 MultiplayerJoinService.RequestJoin(source, code, mod);
                 return;
             }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1")]
-[assembly: AssemblyFileVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyFileVersion("1.6.0")]

--- a/bsrpc.csproj
+++ b/bsrpc.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
-    <LocalRefsDir Condition="Exists('..\ Refs')">..\ Refs</LocalRefsDir>
+    <LocalRefsDir Condition="Exists('..\  Refs')">..\  Refs</LocalRefsDir>
     <GameDirectory>$(LocalRefsDir)</GameDirectory>
     <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
     <!--<PathMap>$(AppOutputBase)=X:\$(AssemblyName)\</PathMap>-->
@@ -80,7 +80,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/bsrpc.csproj
+++ b/bsrpc.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
-    <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
+    <LocalRefsDir Condition="Exists('..\ Refs')">..\ Refs</LocalRefsDir>
     <GameDirectory>$(LocalRefsDir)</GameDirectory>
     <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
     <!--<PathMap>$(AppOutputBase)=X:\$(AssemblyName)\</PathMap>-->
@@ -80,6 +80,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "gameVersion": "1.43.0",
   "dependsOn": {
     "BSIPA": "^4.3.7",
-    "DataPuller": "^2.1.18",
+    "DataPuller": "^3.0.0",
     "DiscordCore": "^4.1.1",
     "BeatSaberMarkupLanguage": "^1.14.1"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "id": "bsrpc",
   "name": "bsrpc",
   "author": "WentTheFox",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Discord Rich Presence integration for Beat Saber",
   "gameVersion": "1.43.0",
   "dependsOn": {


### PR DESCRIPTION
## Context

Companion to WentTheFox/BSDataPuller#13.

DataPuller now sets `MultiplayerLobbySource = "MultiplayerCore"` for any MultiplayerCore-backed lobby and exposes the specific mod/server name (e.g. `"BeatTogether"`) in a new `MultiplayerCoreLobbyMod` field. This PR updates bsrpc to use both.

## Changes

### `DataMappers.cs`
When building the join secret, encodes the mod name as an additional path segment when the field is set:
```
bsrpc://MultiplayerCore/BeatTogether/A1B2C3
```
Secrets without a mod name (vanilla, BSP, or older DataPuller) are unchanged:
```
bsrpc://Vanilla/A1B2C3
```

`activity.Party.Id` is now set to a SHA256 hex digest of the join code instead of the raw code, so Discord's party metadata does not expose the lobby code directly.

### `Plugin.cs` — `OnActivityJoin`
Replaced the previous query-string approach with pure URI path parsing — `AbsolutePath` is split into at most two segments. If two segments are present, the first is the mod name and the second is the join code; if only one, it is the join code with no mod. `using System.Web` removed.

### `Harmony/MultiplayerJoinService.cs`
- Adds `_pendingMod` field alongside `_pendingSource` and `_pendingCode`
- `RequestJoin` gains an optional `modName` parameter; logs it when present
- `Clear()` nulls `_pendingMod`

### `bsrpc.csproj`
`System.Web` reference removed (no longer needed). Nullable reference type annotations (`?`) removed for C# 7.3 compatibility.

### Dependency update
DataPuller dependency bumped from `^2.1.18` to `^3.0.0` in `manifest.json`.

## Routing

No routing logic changes were needed. BSP is still detected by `source == "BeatSaberPlus_Multiplayer"` and handled by `BspJoinService`. All MultiplayerCore-backed servers (BeatTogether, etc.) have `source == "MultiplayerCore"` and go through the existing vanilla lobby-code join path — the mod name is informational only.

## Backwards compatibility

- Old secrets (`bsrpc://Vanilla/CODE`) are still parsed correctly; `modName` is simply `null`.
- Old bsrpc receiving a new three-segment secret will treat the entire path as the join code and fail to match a lobby. Both sides should be updated together.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV24b5vE3V6aHBodsjuJXr)_