### PR TITLE
Update dependency links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,5 @@ The `PlayStateEmoji`, `ModifierEmoji` and `LobbyTypeEmoji` options allow you to 
 
 * BSIPA v4.3.6 (ModAssistant)
 * BeatSaberMarkupLanguage v1.12.5 (ModAssistant)
-* DiscordCore v4.0.0 (ModAssistant)
-* DataPuller v2.2.0 (https://github.com/DJDavid98/BSDataPuller/releases/tag/2.2.0)
+* DiscordCore v4.0.0 (https://github.com/WentTheFox/DiscordCore/releases/tag/v4.0.0)
+* DataPuller v2.2.0 (https://github.com/WentTheFox/BSDataPuller/releases/tag/v2.2.0)


### PR DESCRIPTION
## Summary
Updated the documentation links for DiscordCore and DataPuller dependencies to point to the correct GitHub repository owner.

## Changes
- Updated DiscordCore dependency link from ModAssistant to direct GitHub release link (WentTheFox/DiscordCore)
- Updated DataPuller dependency link to point to WentTheFox's repository instead of DJDavid98's repository
- Both links now reference the specific release versions (v4.0.0 and v2.2.0 respectively)

## Details
These changes ensure that users can easily access the correct source repositories for the project's dependencies. The links now consistently point to WentTheFox's GitHub repositories for both DiscordCore and DataPuller.

https://claude.ai/code/session_01AZt981JxR5Jy7fymAvm7gn